### PR TITLE
Add e2e test task to Makefile.toml

### DIFF
--- a/packages/server/Makefile.toml
+++ b/packages/server/Makefile.toml
@@ -12,3 +12,7 @@ env.EMBERS__TESTNET__PROPOSE_SERVICE_URL = "http://localhost:15402"
 env.EMBERS__TESTNET__READ_NODE_URL       = "http://localhost:15413"
 env.EMBERS__TESTNET__SERVICE_KEY         = "732240A471E12931D858F147165BA1B52C011B92B9E8CD7959AADF06D7ACE622"
 env.RUST_BACKTRACE                       = "full"
+
+[tasks.e2e-test]
+args    = ["run", "pytest"]
+command = "poetry"


### PR DESCRIPTION
- Define a new task for running end-to-end tests using pytest.
